### PR TITLE
Fix High CPU occupancy

### DIFF
--- a/cmd/gq-server/gq-server.go
+++ b/cmd/gq-server/gq-server.go
@@ -47,8 +47,8 @@ func (pair *webPair) serverToRemote() {
 
 func (pair *webPair) remoteToServer() {
 	for {
-		_, err := io.Copy(pair.webServer, pair.remote)
-		if err != nil {
+		length, err := io.Copy(pair.webServer, pair.remote)
+		if err != nil || length == 0 {
 			pair.closePipe()
 			return
 		}

--- a/cmd/gq-server/gq-server.go
+++ b/cmd/gq-server/gq-server.go
@@ -39,9 +39,12 @@ func (pair *ssPair) closePipe() {
 }
 
 func (pair *webPair) serverToRemote() {
-	_, err := io.Copy(pair.remote, pair.webServer)
-	if err != nil {
-		pair.closePipe()
+	for {
+		length, err := io.Copy(pair.remote, pair.webServer)
+		if err != nil || length == 0 {
+			pair.closePipe()
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
The dead loop causes high CPU occupancy. Quit loop when no more byte to copy.