### PR TITLE
Feature auto-gen version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 default: all
 
-client:
+update-version:
+	./update-version.sh
+
+client: update-version
 	go get github.com/cbeuw/gotfo
 	go build -o ./build/gq-client ./cmd/gq-client 
 
-server:
+server: update-version
 	go get github.com/cbeuw/gotfo
 	go build -o ./build/gq-server ./cmd/gq-server
 

--- a/cmd/gq-client/gq-client.go
+++ b/cmd/gq-client/gq-client.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cbeuw/GoQuiet/gqclient"
 	"github.com/cbeuw/GoQuiet/gqclient/TLS"
 	"github.com/cbeuw/gotfo"
+	"fmt"
 	"io"
 	"log"
 	"net"
@@ -134,8 +135,6 @@ func initSequence(ssConn net.Conn, sta *gqclient.State) {
 
 }
 
-var version string
-
 func main() {
 	// Should be 127.0.0.1 to listen to ss-local on this machine
 	var localHost string
@@ -167,7 +166,7 @@ func main() {
 		flag.Parse()
 
 		if *askVersion {
-			log.Println("gq-client version: " + version)
+			fmt.Printf("gq-client %s\n", version)
 			return
 		}
 

--- a/cmd/gq-client/version.go
+++ b/cmd/gq-client/version.go
@@ -1,0 +1,3 @@
+package main
+
+const version = "master"

--- a/cmd/gq-server/gq-server.go
+++ b/cmd/gq-server/gq-server.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"github.com/cbeuw/GoQuiet/gqserver"
 	"github.com/cbeuw/gotfo"
+	"fmt"
 	"io"
 	"log"
 	"net"
@@ -197,8 +198,6 @@ func usedRandomCleaner(sta *gqserver.State) {
 	}
 }
 
-var version string
-
 func main() {
 	// Should be 127.0.0.1 to listen to ss-server on this machine
 	var localHost string
@@ -224,7 +223,7 @@ func main() {
 		flag.Parse()
 
 		if *askVersion {
-			log.Println("gq-server verison: " + version)
+			fmt.Printf("gq-server %s\n", version)
 			return
 		}
 

--- a/cmd/gq-server/version.go
+++ b/cmd/gq-server/version.go
@@ -1,0 +1,3 @@
+package main
+
+const version = "master"

--- a/update-version.sh
+++ b/update-version.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+ver=$(git log -n 1 --pretty=oneline --format=%D | awk -F, '{print $1}' | awk '{print $3}')
+if [ "$ver" = "master" ]
+then
+    ver="master ($(git log -n 1 --pretty=oneline --format=%h))"
+fi
+sed -i "s/^const version = .*$/const version = \"$ver\"/" cmd/gq-server/version.go
+sed -i "s/^const version = .*$/const version = \"$ver\"/" cmd/gq-client/version.go


### PR DESCRIPTION
EDIT 2018-04-10T10:49:44Z

`make` can make binaries with version report as,

* like "gq-server v1.1.1" when *git tags* is available at build time, which means it's a *release*.
* like "gq-server master-abc123" when built on git master branch w/o any tag (abc123 is the commit id), which means it's a master branch binary.

I assume that we use *git tag* as *release version*.