### PR TITLE
fix: listen and connect on ipv6 host

### DIFF
--- a/cmd/gq-client/gq-client.go
+++ b/cmd/gq-client/gq-client.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os"
 	"time"
+	"strings"
 
 	"github.com/cbeuw/GoQuiet/gqclient"
 	"github.com/cbeuw/GoQuiet/gqclient/TLS"
@@ -193,6 +194,12 @@ func main() {
 	err := sta.ParseConfig(pluginOpts)
 	if err != nil {
 		log.Fatal(err)
+	}
+	if strings.IndexByte(sta.SS_LOCAL_HOST, ':') != -1 {
+	    sta.SS_LOCAL_HOST = "[" + sta.SS_LOCAL_HOST + "]"
+	}
+	if strings.IndexByte(sta.SS_REMOTE_HOST, ':') != -1 {
+	    sta.SS_REMOTE_HOST = "[" + sta.SS_REMOTE_HOST + "]"
 	}
 
 	if sta.SS_LOCAL_PORT == "" {

--- a/cmd/gq-server/gq-server.go
+++ b/cmd/gq-server/gq-server.go
@@ -245,6 +245,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("Configuration file error: %v", err)
 	}
+	if strings.IndexByte(sta.SS_LOCAL_HOST, ':') != -1 {
+	    sta.SS_LOCAL_HOST = "[" + sta.SS_LOCAL_HOST + "]"
+	}
+	if strings.IndexByte(sta.SS_REMOTE_HOST, ':') != -1 {
+	    sta.SS_REMOTE_HOST = "[" + sta.SS_REMOTE_HOST + "]"
+	}
 
 	if sta.Key == "" {
 		log.Fatal("Key cannot be empty")
@@ -272,10 +278,10 @@ func main() {
 	// When listening on an IPv6 and IPv4, SS gives REMOTE_HOST as e.g. ::|0.0.0.0
 	listeningIP := strings.Split(sta.SS_REMOTE_HOST, "|")
 	for i, ip := range listeningIP {
-		if net.ParseIP(ip).To4() == nil {
+		// if net.ParseIP(ip).To4() == nil {
 			// IPv6 needs square brackets
-			ip = "[" + ip + "]"
-		}
+			// ip = "[" + ip + "]"
+		// }
 
 		// The last listener must block main() because the program exits on main return.
 		if i == len(listeningIP)-1 {


### PR DESCRIPTION
GoQuiet work unusual under shadowsocks-libev SIP003 mode when `REMOTE_HOST` or `LOCAL_HOST` is IPv6 address.

```
~/GoQuiet # ss-local -v -s ::1 -p 12345 -b 0.0.0.0 -l 1081 -k dnomd343 -m aes-256-ctr --plugin ./gq-client --plugin-opts "ServerName=www.bing.com;key=dnomd343;TicketTimeHint=300;Browser=chrome"
 2022-03-04 15:55:52 INFO: plugin "./gq-client" enabled
 2022-03-04 15:55:52 INFO: initializing ciphers... aes-256-ctr
 2022-03-04 15:55:52 INFO: Stream ciphers are insecure, therefore deprecated, and should be almost always avoided.
 2022-03-04 15:55:52 INFO: listening at 0.0.0.0:1081
 2022-03-04 15:55:52 INFO: running from root user
dump start =>
  localHost -> ::1
  localPort -> 34859
  remoteHost -> ::1
  remotePort -> 12345
  pluginOpts -> ServerName=www.bing.com;key=dnomd343;TicketTimeHint=300;Browser=chrome
2022/03/04 15:55:52 gq-client.go:219: listen tcp: address ::1:34859: too many colons in address
 2022-03-04 15:55:52 ERROR: plugin service exit unexpectedly
 2022-03-04 15:55:52 INFO: closed gracefully
 2022-03-04 15:55:52 INFO: error on terminating the plugin.
```